### PR TITLE
Set project version to 1.0-SNAPSHOT in build configurations

### DIFF
--- a/Feeds/build.gradle.kts
+++ b/Feeds/build.gradle.kts
@@ -1,4 +1,5 @@
 description = "Feeds"
+version = "1.0-SNAPSHOT"
 
 dependencies {
   implementation(libs.imapi)

--- a/Transforms/build.gradle.kts
+++ b/Transforms/build.gradle.kts
@@ -1,4 +1,5 @@
 description = "Transforms"
+version = "1.0-SNAPSHOT"
 
 dependencies {
   implementation(libs.imapi)


### PR DESCRIPTION
Added the `version` property to `Feeds` and `Transforms` build scripts to define the project version as `1.0-SNAPSHOT`. This ensures versioning consistency and prepares the modules for proper release management.